### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,45 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.ref_name }}-lint
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Go Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Golang Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Lint Go
+        uses: golangci/golangci-lint-action@v6
+
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Lint Actions
+        uses: reviewdog/action-actionlint@v1
+        with:
+          actionlint_flags: -shellcheck ""

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,91 @@
+linters-settings:
+  misspell:
+    locale: US
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+  govet:
+    enable-all: true
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    # - contextcheck
+    - copyloopvar
+    - dupword
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - fatcontext
+    - forcetypeassert
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocritic
+    - godot
+    - gofmt
+    - gofumpt
+    - goimports
+    - gosec
+    - gosimple
+    - gosmopolitan
+    - govet
+    - ineffassign
+    - intrange
+    - makezero
+    - misspell
+    - musttag
+    - nilerr
+    - noctx
+    - nolintlint
+    - paralleltest
+    - perfsprint
+    - prealloc
+    - predeclared
+    - reassign
+    - revive
+    - staticcheck
+    - stylecheck
+    - tagalign
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
+    # - wrapcheck
+  disable-all: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  timeout: 5m

--- a/README.md
+++ b/README.md
@@ -1,55 +1,61 @@
 # echo
-a middleware for the echov4 web framework to use opentracing
+
+[![CI](https://github.com/opentracing-contrib/echo/actions/workflows/ci.yml/badge.svg)](https://github.com/opentracing-contrib/echo/actions/workflows/ci.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/opentracing-contrib/echo)](https://goreportcard.com/report/github.com/opentracing-contrib/echo)
+[![GoDoc](https://godoc.org/github.com/opentracing-contrib/echo?status.svg)](https://pkg.go.dev/github.com/opentracing-contrib/echo)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/opentracing-contrib/echo?logo=github&sort=semver)](https://github.com/opentracing-contrib/echo/releases/latest)
+
+A middleware for the echov4 web framework to use OpenTracing
 
 ```go
 package main
 
 import (
-	"github.com/labstack/echo/v4"
-	apmecho "github.com/opentracing-contrib/echo"
-	"github.com/opentracing-contrib/echo/examples/tracer"
-	"github.com/opentracing/opentracing-go"
-	"net/http"
-	"os"
+  "github.com/labstack/echo/v4"
+  apmecho "github.com/opentracing-contrib/echo"
+  "github.com/opentracing-contrib/echo/examples/tracer"
+  "github.com/opentracing/opentracing-go"
+  "net/http"
+  "os"
 )
 
 const (
-	DefaultComponentName = "echo-demo"
+  DefaultComponentName = "echo-demo"
 )
 
 func main() {
 
-	flag := os.Getenv("JAEGER_ENABLED")
-	if flag == "true" {
-		// 1. init tracer
-		tracer, closer := tracer.Init(DefaultComponentName)
-		if closer != nil {
-			defer closer.Close()
-		}
-		// 2. ste the global tracer
-		if tracer != nil {
-			opentracing.SetGlobalTracer(tracer)
-		}
-	}
+  flag := os.Getenv("JAEGER_ENABLED")
+  if flag == "true" {
+    // 1. init tracer
+    tracer, closer := tracer.Init(DefaultComponentName)
+    if closer != nil {
+      defer closer.Close()
+    }
+    // 2. ste the global tracer
+    if tracer != nil {
+      opentracing.SetGlobalTracer(tracer)
+    }
+  }
 
-	e := echo.New()
+  e := echo.New()
 
-	if flag == "true" {
-		// 3. use the middleware
-		e.Use(apmecho.Middleware(DefaultComponentName))
-	}
+  if flag == "true" {
+    // 3. use the middleware
+    e.Use(apmecho.Middleware(DefaultComponentName))
+  }
 
-	e.GET("/", func(c echo.Context) error {
-		return c.String(http.StatusOK, "Hello, World!")
-	})
+  e.GET("/", func(c echo.Context) error {
+    return c.String(http.StatusOK, "Hello, World!")
+  })
 
-	e.Logger.Fatal(e.Start(":1323"))
+  e.Logger.Fatal(e.Start(":1323"))
 }
 
 ```
 
 Example: [echo-example](./examples)
 
-![](./examples/imgs/img1.jpg)
+![Echo tracing example screenshot 1](./examples/imgs/img1.jpg)
 
-![](./examples/imgs/img2.jpg)
+![Echo tracing example screenshot 2](./examples/imgs/img2.jpg)


### PR DESCRIPTION
This pull request includes several changes to add a linting workflow, update the README, and improve the middleware code. The most important changes include the addition of a GitHub Actions workflow for linting, updates to the `.golangci.yml` configuration, enhancements to the `README.md` file, and improvements in the `middleware.go` file.

### Linting and Configuration:

* Added a GitHub Actions workflow for linting Go code and GitHub Actions files (`.github/workflows/lint.yml`).
* Updated `.golangci.yml` to configure various linters and their settings, enabling a comprehensive set of linting rules.

### Documentation:

* Enhanced `README.md` by adding badges for CI status, Go Report Card, GoDoc, and GitHub release, and provided a clearer description of the middleware.
* Updated image descriptions in the `README.md` example section to improve clarity.

### Middleware Code Improvements:

* Reorganized imports in `middleware.go` for better readability and compliance with linting rules.
* Removed unnecessary semicolon and added a `nolint` directive to the `spanObserver` function.
* Added validation for HTTP status codes to ensure they are within a valid range before setting the span tag.